### PR TITLE
Fix register validation issues

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -57,6 +57,7 @@ export default function RegisterPage() {
 
         if (formData.password !== confirmPassword) {
             setError('Passwords do not match');
+            setIsSubmitting(false);
             return;
         }
 
@@ -154,8 +155,8 @@ export default function RegisterPage() {
 
                         <div>
                             <input
-                                id="confirm-password"
-                                name="confirm-password"
+                                id="confirmPassword"
+                                name="confirmPassword"
                                 type="password"
                                 placeholder="Confirm Password"
                                 required


### PR DESCRIPTION
## Summary
- prevent submit button from remaining disabled when passwords don't match
- correct confirm password field name so validation works

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687b0fd984d88330beacb39fb1ec3f28